### PR TITLE
updated libsodium version to 1.0.2

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -31,7 +31,7 @@ then
   echo "done"
 
   echo -n "-----> Compiling libsodium... "
-  make && make check && make install
+  make &> /dev/null
   echo "done"
 fi
 

--- a/bin/compile
+++ b/bin/compile
@@ -31,7 +31,7 @@ then
   echo "done"
 
   echo -n "-----> Compiling libsodium... "
-  make &> /dev/null
+  make && make check && make install
   echo "done"
 fi
 

--- a/bin/compile
+++ b/bin/compile
@@ -6,7 +6,7 @@ mkdir -p "$1" "$2"
 BUILD_PATH=$(cd "$1/" && pwd)
 CACHE_PATH=$(cd "$2/" && pwd)
 
-VERSION=1.0.0
+VERSION=1.0.2
 SODIUM_DIR=libsodium-$VERSION
 TARBALL=$SODIUM_DIR.tar.gz
 TARBALL_URL=https://download.libsodium.org/libsodium/releases/$TARBALL

--- a/bin/release
+++ b/bin/release
@@ -3,5 +3,5 @@
 cat <<EOF
 ---
 config_vars:
-  LD_LIBRARY_PATH: vendor/libsodium-1.0.0/src/libsodium/.libs
+  LD_LIBRARY_PATH: vendor/libsodium-1.0.2/src/libsodium/.libs
 EOF


### PR DESCRIPTION
Latest heroku builds weren't working with the old version of libsodium. Updating to the 1.0.2 version seems to have fixed the issues. It should probably let you select a version in the future if that's possible
